### PR TITLE
implementation for issue #9

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/yamkins/ActiveNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/yamkins/ActiveNotifier.java
@@ -6,6 +6,13 @@ import hudson.model.Result;
 import hudson.model.Run;
 
 import javax.ws.rs.core.Response;
+import java.awt.*;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Logger;
 
 /**
@@ -39,23 +46,62 @@ public class ActiveNotifier implements FineGrainedNotifier {
     }
 
     @Override
-    public void completed(AbstractBuild r) {
-        AbstractProject<?, ?> project = r.getProject();
-        Result result = r.getResult();
+    public void completed(AbstractBuild build) {
+        AbstractProject<?, ?> project = build.getProject();
+        Result result = build.getResult();
         AbstractBuild<?, ?> previousBuild = project.getLastBuild().getPreviousBuild();
         Result previousResult = (previousBuild != null) ? previousBuild.getResult() : Result.SUCCESS;
-        String message = getBuildStatusMessage(r);
+
+
         if ((result == Result.ABORTED && notifier.isNotifyAborted() )
                 || (result == Result.FAILURE && notifier.isNotifyFailure())
                 || (result == Result.NOT_BUILT && notifier.isNotifyNotBuilt())
                 || (result == Result.SUCCESS && previousResult == Result.FAILURE && notifier.isNotifyBackToNormal())
                 || (result == Result.SUCCESS && notifier.isNotifySuccess())
                 || (result == Result.UNSTABLE && notifier.isNotifyUnstable())) {
+
             YammerService service = notifier.newYammerService();
-            Response response = service.postMessage(message);
+
+            Response response = null;
+
+            if(notifier.getDescriptor().useOpenGraphMessageFormat()) {
+                // maybe null
+                String replyToMessageId = getReplyToMesage(build.getProject());
+
+                URL buildUrl = createBuildUrl(notifier.getBuildServerUrl(), build.getUrl());
+                Map<OpenGraph, String> ogMap = createOpenGraphProperties(notifier, build);
+
+                response = service.postMessage(buildUrl, ogMap, replyToMessageId);
+            }else {
+                String message = getBuildStatusMessage(build);
+                response = service.postMessage(message);
+            }
+
             int status = response.getStatus();
+
+
             if(status == 201) {
-                logger.info("Sent build message to Yammer group: " + message);
+                logger.info("Sent build message to Yammer group: ");
+
+                String id = extractMessageId(response);
+
+                try {
+                    ReplyToMessageIdJobProperty p = (ReplyToMessageIdJobProperty) project.getProperty(ReplyToMessageIdJobProperty.class);
+                    if (p == null) {
+                        p = new ReplyToMessageIdJobProperty("");
+                    }
+
+                    if(result == Result.SUCCESS)
+                        p.setReplyMessageId("");
+                    else
+                        p.setReplyMessageId(id);
+
+                    project.addProperty(p);
+                    project.save();
+
+                } catch (IOException e) {
+                   logger.throwing(ActiveNotifier.class.getName(), "completed(AbstractBuild)", e);
+                }
             } else {
                 logger.warning("Unable to send message to Yammer group HTTP status code: " + status);
                 logger.warning(response.readEntity(String.class));
@@ -63,22 +109,102 @@ public class ActiveNotifier implements FineGrainedNotifier {
         }
     }
 
-    String getBuildStatusMessage(AbstractBuild r) {
+    private String extractMessageId(Response response) {
+
+        String location = response.getHeaderString("Location");
+        logger.info(location);
+        return location.substring(location.lastIndexOf("/")+1, location.length());
+    }
+
+    /**
+     * @param project projectconfiguration with optional replyToMessageId
+     * @return replyToMessageId if configured in project, otherwise null
+     */
+    private String getReplyToMesage(AbstractProject project) {
+
+        ReplyToMessageIdJobProperty property = (ReplyToMessageIdJobProperty) project.getProperty(ReplyToMessageIdJobProperty.class);
+
+        return property != null? property.getReplyToMessageId(): null;
+    }
+
+    protected String getBuildStatusMessage(AbstractBuild r) {
         MessageBuilder message = new MessageBuilder(notifier, r);
         message.appendStatusMessage();
         message.appendDuration();
         return message.appendOpenLink().toString();
     }
 
+    private URL createBuildUrl(String buildServerUrl, String buildUrl) {
+        try {
+            return new URL (buildServerUrl+buildUrl);
+        } catch (MalformedURLException e) {
+            logger.info("createBuildUrl failed - "+e.getMessage());
+            return null;
+        }
+    }
+
+
+    private Map<OpenGraph, String> createOpenGraphProperties(YamkinsPlugin plugin, AbstractBuild build) {
+
+        Map<OpenGraph, String> map = new HashMap<OpenGraph, String>();
+        map.put(OpenGraph.TITLE, createTitle(build));
+
+        if(notifier.getDescriptor().getAttachOpenGraphImage())
+            map.put(OpenGraph.IMAGE, createDummyImageUrl(build));
+
+        map.put(OpenGraph.DESCRIPTION, build.getDurationString()+" - "+build.getTimestampString());
+
+        return map;
+    }
+
+
+    private String createDummyImageUrl(AbstractBuild build) {
+
+        Color background = build.getResult().color.getBaseColor();
+        Color forground = Color.WHITE;
+
+        String text = MessageBuilder.getStatusMessage(build);
+
+        if(build.getResult() == Result.SUCCESS) {
+           background = Color.GREEN;
+           forground = Color.BLACK;
+        }
+        else if (build.getResult() == Result.UNSTABLE) {
+            forground = Color.BLACK;
+            background = Color.YELLOW;
+        }
+
+        return createDummyImageUrl(text, 300, 300, forground, background);
+    }
+
+    private  String createTitle(AbstractBuild build) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(build.getProject().getDisplayName()).append(" - ");
+        builder.append(build.getDisplayName()).append(" : ").append(MessageBuilder.getStatusMessage(build));
+        return builder.toString();
+
+    }
+
+    private  String createDummyImageUrl(String text, int width, int height, Color foreground, Color background){
+        StringBuilder builder = new StringBuilder("http://dummyimage.com/");
+        builder.append(width).append("x").append(height).append("/");
+        builder.append(Integer.toHexString(background.getRGB()).substring(2)).append("/");
+        builder.append(Integer.toHexString(foreground.getRGB()).substring(2)).append(".png");
+        builder.append("&text=").append(URLEncoder.encode(text));
+        return builder.toString();
+    }
+
+
     public static class MessageBuilder {
         private StringBuffer message;
         private YamkinsPlugin notifier;
         private AbstractBuild build;
 
-        public MessageBuilder(YamkinsPlugin notifier, AbstractBuild build) {
-            this.notifier = notifier;
-            this.message = new StringBuffer();
-            this.build = build;
+
+        public MessageBuilder(YamkinsPlugin aNotifier, AbstractBuild aBuild) {
+            notifier = aNotifier;
+            build = aBuild;
+            message = new StringBuffer();
             startMessage();
         }
 

--- a/src/main/java/org/jenkinsci/plugins/yamkins/OpenGraph.java
+++ b/src/main/java/org/jenkinsci/plugins/yamkins/OpenGraph.java
@@ -1,0 +1,39 @@
+package org.jenkinsci.plugins.yamkins;
+
+/**
+ * enum representing the queryparmeters for the messages.json resource in the yammer rest api <br>
+ * <a href="https://developer.yammer.com/restapi/#rest-messages>POST Yammer Message</a>
+ * @author Bernd Kiefer <b.kiefer@raion.de>
+ */
+public enum OpenGraph {
+
+    /** The title of your object as it should appear within the graph */
+    TITLE("og_title"),
+
+    /**  The canonical URL of the OG object that will be used as its permanent ID in the graph */
+    URL("og_url"),
+
+    /** A thumbnail image URL which represents your object in the graph */
+    IMAGE("og_image"),
+
+    /** A one to two sentence description of your object.*/
+    DESCRIPTION("og_description"),
+
+    /** An identifier to relate objects from a common domain, e.g., “Yammer Blog”. */
+    SITE_NAME("og_site_name"),
+
+    /** Structured metadata about this object that can be used by clients for custom rendering. */
+    META("og_meta");
+
+
+    private final String name;
+
+    OpenGraph(String aName) {
+        name = aName;
+    }
+
+    @Override
+    public String toString() { return name; }
+
+
+}

--- a/src/main/java/org/jenkinsci/plugins/yamkins/ReplyToMessageIdJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/yamkins/ReplyToMessageIdJobProperty.java
@@ -1,0 +1,62 @@
+package org.jenkinsci.plugins.yamkins;
+
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.Job;
+import hudson.model.JobProperty;
+import hudson.model.JobPropertyDescriptor;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+public class ReplyToMessageIdJobProperty extends JobProperty<AbstractProject<?, ?>> {
+
+
+        String replyToMessageId;
+
+        @DataBoundConstructor
+        public ReplyToMessageIdJobProperty(String messageId) {
+            replyToMessageId = messageId;
+        }
+
+        public String getReplyToMessageId() {
+            return replyToMessageId;
+        }
+
+        public void setReplyMessageId(String messageId) {
+            this.replyToMessageId = messageId;
+    }
+
+        @Override
+        public JobPropertyDescriptor getDescriptor() {
+            return DESCRIPTOR;
+        }
+
+        @Extension
+        public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+
+
+
+    public static class DescriptorImpl extends JobPropertyDescriptor {
+
+        public DescriptorImpl() {
+            super(ReplyToMessageIdJobProperty.class);
+            load();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Sets the message id of the Yammer message Jenkins posted to in case of failing or unstable build";
+        }
+
+        @Override
+        public boolean isApplicable(Class<? extends Job> jobType) {
+            return AbstractProject.class.isAssignableFrom(jobType);
+        }
+
+        @Override
+        public JobProperty<?> newInstance(StaplerRequest request, JSONObject formData) {
+            return request.bindJSON(ReplyToMessageIdJobProperty.class, formData);
+        }
+    }
+ }

--- a/src/main/java/org/jenkinsci/plugins/yamkins/YamkinsListener.java
+++ b/src/main/java/org/jenkinsci/plugins/yamkins/YamkinsListener.java
@@ -34,3 +34,4 @@ public class YamkinsListener extends RunListener<AbstractBuild> {
     }
 
 }
+

--- a/src/main/java/org/jenkinsci/plugins/yamkins/YamkinsPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/yamkins/YamkinsPlugin.java
@@ -114,6 +114,9 @@ public class YamkinsPlugin extends Notifier {
 
         private String apiToken;
         private String buildServerUrl;
+        private Boolean useOpenGraphMessageFormat;
+        private Boolean attachOpenGraphImage;
+
 
         public DescriptorImpl() {
             load();
@@ -156,6 +159,11 @@ public class YamkinsPlugin extends Notifier {
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
             apiToken = formData.getString("apiToken");
             buildServerUrl = formData.getString("buildServerUrl");
+            useOpenGraphMessageFormat = formData.getBoolean("useOpenGraphMessageFormat");
+
+            if(formData.has("attachOpenGraphImage"))
+              attachOpenGraphImage = formData.getBoolean("attachOpenGraphImage");
+
             save();
             return super.configure(req, formData);
         }
@@ -174,6 +182,22 @@ public class YamkinsPlugin extends Notifier {
          */
         public String getBuildServerUrl() {
             return buildServerUrl;
+        }
+
+        /**
+         * Returns the globally configured MessageFormat
+         * @return  false = plaintext, true = OpenGraph format
+         */
+        public Boolean useOpenGraphMessageFormat() {
+            return useOpenGraphMessageFormat;
+        }
+
+        /**
+         * image will be attached to the opengraph message if true
+         * @return true / false
+         */
+        public Boolean getAttachOpenGraphImage() {
+            return attachOpenGraphImage;
         }
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/yamkins/YamkinsPlugin/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/yamkins/YamkinsPlugin/config.jelly
@@ -4,6 +4,12 @@
     <f:textbox />
   </f:entry>
 
+ <!--
+  <f:entry title="ReplyTo Message ID" field="repliedToId">
+      <f:textbox />
+    </f:entry>
+  -->
+
   <f:section title="Notification Triggers">
 
       <f:entry    title       = "Successful Build"

--- a/src/main/resources/org/jenkinsci/plugins/yamkins/YamkinsPlugin/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/yamkins/YamkinsPlugin/global.jelly
@@ -13,10 +13,36 @@
         <f:entry   title       = "Jenkins Build Server URL"
                    description = "URL of this Jenkins instance including slash at the end."
                    field       = "buildServerUrl">
-        <f:textbox value       = "${descriptor.getBuildServerUrl()}"
-                   default     = "http://example.com/jenkins/"
-                   name        = "buildServerUrl" />
+            <f:textbox value       = "${descriptor.getBuildServerUrl()}"
+                       default     = "http://example.com/jenkins/"
+                       name        = "buildServerUrl" />
         </f:entry>
+
+       <f:entry title       = "Post as OpenGraph Object"
+                description = "submits Notifications in OpenGraph format"
+                field       = "useOpenGraphMessageFormat">
+
+         <f:checkbox checked = "${descriptor.useOpenGraphMessageFormat()}"
+                     default = "false"
+                     name    = "useOpenGraphMessageFormat"/>
+       </f:entry>
+
+        <!--
+        <f:optionalBlock checked = "${descriptor.useOpenGraphMessageFormat()}"
+                         title    = "OpenGraph Options"
+                         field   = "optionalImageBlock">
+        -->
+               <f:entry title    = "use Image highlighting"
+                       description = "attach Images to the message to highlight the result of the build"
+                       field       = "attachOpenGraphImage">
+
+                <f:checkbox checked = "${descriptor.attachOpenGraphImage()}"
+                            default = "false"
+                            name    ="attachOpenGraphImage"/>
+               </f:entry>
+        <!--
+        </f:optionalBlock>
+        -->
 
     </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/yamkins/YamkinsPlugin/help-useOpenGraphMessageFormat.html
+++ b/src/main/resources/org/jenkinsci/plugins/yamkins/YamkinsPlugin/help-useOpenGraphMessageFormat.html
@@ -1,0 +1,5 @@
+<div>
+  Notifications are submitted to the Yammer group as OpenGraph object attachment, see
+  <pre>https://developer.yammer.com/restapi/#rest-messages</pre>
+  for detailed information
+</div>

--- a/src/test/java/meury/com/yamkins/Playground.java
+++ b/src/test/java/meury/com/yamkins/Playground.java
@@ -1,5 +1,7 @@
 package meury.com.yamkins;
 
+import org.jenkinsci.plugins.yamkins.YammerService;
+
 import javax.ws.rs.core.Response;
 import java.util.Date;
 


### PR DESCRIPTION
- optional opengraph message format, including optional status image
- 'back to normal' build messages will be posted as reply message to the previous 'failure' buildmessages
